### PR TITLE
Remove existing tap on audio bus before installation

### DIFF
--- a/src/ios/SpeechRecognition.m
+++ b/src/ios/SpeechRecognition.m
@@ -172,6 +172,9 @@
                     [self deactivateAudioSession];
                 }
             }];
+
+            // Remove any existing tap on the bus first
+            [inputNode removeTapOnBus:0];
             
             NSLog(@"startListening() installTapOnBus");
             


### PR DESCRIPTION
Rapid calls of - (void)startListening:(CDVInvokedUrlCommand *)command lead to crash when it tries to install tap on audio bus. We want to make sure that existing tap removed before install a new one. 

Changes:
Remove existing tap on the audio bus before installation a new one.